### PR TITLE
docs: no name in IlpReject

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ const binaryFulfill = packet.serializeIlpFulfill({
 // not to be confused with IlpRejection:
 const binaryReject = packet.serializeIlpReject({
   code: 'F00',
-  name: 'Bad Request',
   triggeredBy: 'g.us.nexus.gateway',
   message: 'more details, human-readable',
   data: Buffer.from('more details, machine-readable')


### PR DESCRIPTION
See https://github.com/interledger/rfcs/blob/master/asn1/InterledgerProtocol.asn#L41, there is no name field, also the code doesn't use it.