### PR TITLE
Feat: add Error classes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,8 @@ import { stringToTwoNumbers, twoNumbersToString } from './src/utils/uint64'
 import Long = require('long')
 import * as assert from 'assert'
 
-export const Errors = require('./src/errors')
+import * as errors from './src/errors'
+export const Errors = errors
 
 export enum Type {
   TYPE_ILP_PAYMENT = 1,

--- a/index.ts
+++ b/index.ts
@@ -32,7 +32,7 @@ export enum Type {
 export interface IlpErrorClass {
   message: string,
   ilpErrorCode?: string,
-  ilpData?: Buffer
+  ilpErrorData?: Buffer
 }
 
 export const errorToReject = (address: string, error: IlpErrorClass) => {
@@ -40,7 +40,7 @@ export const errorToReject = (address: string, error: IlpErrorClass) => {
     code: error.ilpErrorCode || 'F00',
     triggeredBy: address,
     message: error.message || '',
-    data: error.ilpData || Buffer.alloc(0)
+    data: error.ilpErrorData || Buffer.alloc(0)
   })
 }
 

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,8 @@ import { stringToTwoNumbers, twoNumbersToString } from './src/utils/uint64'
 import Long = require('long')
 import * as assert from 'assert'
 
+export const Errors = require('./src/errors')
+
 export enum Type {
   TYPE_ILP_PAYMENT = 1,
   TYPE_ILQP_LIQUIDITY_REQUEST = 2,
@@ -24,6 +26,21 @@ export enum Type {
   TYPE_ILP_PREPARE = 12,
   TYPE_ILP_FULFILL = 13,
   TYPE_ILP_REJECT = 14
+}
+
+export interface IlpErrorClass {
+  message: string,
+  ilpErrorCode?: string,
+  ilpData?: Buffer
+}
+
+export const errorToReject = (address: string, error: IlpErrorClass) => {
+  return serializeIlpReject({
+    code: error.ilpErrorCode || 'F00',
+    triggeredBy: address,
+    message: error.message || '',
+    data: error.ilpData || Buffer.alloc(0)
+  })
 }
 
 export const serializeEnvelope = (type: number, contents: Buffer) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ilp-packet",
-  "version": "2.0.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,7 +13,7 @@
     "@types/chai": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
-      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
+      "integrity": "sha1-DrIixzU63ejgmAvqBBZdTTtq/vM=",
       "dev": true
     },
     "@types/long": {
@@ -53,7 +53,7 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
       "dev": true,
       "requires": {
         "color-convert": "1.9.1"
@@ -164,7 +164,7 @@
     "bignumber.js": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+      "integrity": "sha1-+85j8Jd2swAKgxhbrc3lJdrzSDM="
     },
     "boom": {
       "version": "2.10.1",
@@ -220,7 +220,7 @@
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -254,7 +254,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -278,7 +278,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "concat-map": {
@@ -322,7 +322,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -331,7 +331,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.5"
@@ -346,7 +346,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
       "dev": true
     },
     "doctrine": {
@@ -394,6 +394,11 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
+    },
+    "extensible-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
+      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -450,7 +455,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -464,7 +469,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "har-schema": {
@@ -665,7 +670,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -689,7 +694,7 @@
     "mocha": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2399,7 +2404,7 @@
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -2408,13 +2413,13 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "sntp": {
@@ -2435,7 +2440,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
@@ -2495,7 +2500,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
@@ -2574,7 +2579,7 @@
     "tslint-config-standard": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-7.0.0.tgz",
-      "integrity": "sha512-QCrLt8WwiRgZpRSgRsk6cExy8/Vipa/5fHespm4Q1ly90EB6Lni04Ub8dkEW10bV3fPN3SkxEwj41ZOe/knCZA==",
+      "integrity": "sha1-R7vyVXjtIhJFb4ktUeGr6ISinxU=",
       "dev": true,
       "requires": {
         "tslint-eslint-rules": "4.1.1"
@@ -2627,7 +2632,7 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI=",
       "dev": true
     },
     "typescript": {
@@ -2645,7 +2650,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "v8flags": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "bignumber.js": "^5.0.0",
+    "extensible-error": "^1.0.2",
     "long": "^3.2.0",
     "oer-utils": "^1.3.2"
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -97,7 +97,7 @@ export interface AmountTooLargeErrorOpts {
 
 export class AmountTooLargeError extends BaseError {
   public ilpErrorCode: string
-  public ilpData: Buffer
+  public ilpErrorData: Buffer
   constructor (message: string, opts: AmountTooLargeErrorOpts) {
     super(message)
     this.ilpErrorCode = codes.F08_AMOUNT_TOO_LARGE
@@ -106,17 +106,17 @@ export class AmountTooLargeError extends BaseError {
     writer.writeUInt64(stringToTwoNumbers(opts.receivedAmount))
     writer.writeUInt64(stringToTwoNumbers(opts.maximumAmount))
 
-    this.ilpData = writer.getBuffer()
+    this.ilpErrorData = writer.getBuffer()
   }
 }
 
 export class FinalApplicationError extends BaseError {
   public ilpErrorCode: string
-  public ilpData: Buffer
+  public ilpErrorData: Buffer
   constructor (message: string, data: Buffer) {
     super(message)
     this.ilpErrorCode = codes.F99_APPLICATION_ERROR
-    this.ilpData = data
+    this.ilpErrorData = data
   }
 }
 
@@ -170,11 +170,11 @@ export class RateLimitedError extends BaseError {
 
 export class TemporaryApplicationError extends BaseError {
   public ilpErrorCode: string
-  public ilpData: Buffer
+  public ilpErrorData: Buffer
   constructor (message: string, data: Buffer) {
     super(message)
     this.ilpErrorCode = codes.T99_APPLICATION_ERROR
-    this.ilpData = data
+    this.ilpErrorData = data
   }
 }
 
@@ -204,10 +204,10 @@ export class InsufficientTimeoutError extends BaseError {
 
 export class RelativeApplicationError extends BaseError {
   public ilpErrorCode: string
-  public ilpData: Buffer
+  public ilpErrorData: Buffer
   constructor (message: string, data: Buffer) {
     super(message)
     this.ilpErrorCode = codes.R99_APPLICATION_ERROR
-    this.ilpData = data
+    this.ilpErrorData = data
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,213 @@
+import { Writer } from 'oer-utils'
+import { stringToTwoNumbers, twoNumbersToString } from './utils/uint64'
+import BaseError = require('extensible-error')
+
+export const codes = {
+  F00_BAD_REQUEST: 'F00',
+  F01_INVALID_PACKET: 'F01',
+  F02_UNREACHABLE: 'F02',
+  F03_INVALID_AMOUNT: 'F03',
+  F04_INSUFFICIENT_DESTINATION_AMOUNT: 'F04',
+  F05_WRONG_CONDITION: 'F05',
+  F06_UNEXPECTED_PAYMENT: 'F06',
+  F07_CANNOT_RECEIVE: 'F07',
+  F08_AMOUNT_TOO_LARGE: 'F08',
+  F99_APPLICATION_ERROR: 'F99',
+  T00_INTERNAL_ERROR: 'T00',
+  T01_PEER_UNREACHABLE: 'T01',
+  T02_PEER_BUSY: 'T02',
+  T03_CONNECTOR_BUSY: 'T03',
+  T04_INSUFFICIENT_LIQUIDITY: 'T04',
+  T05_RATE_LIMITED: 'T05',
+  T99_APPLICATION_ERROR: 'T99',
+  R00_TRANSFER_TIMED_OUT: 'R00',
+  R01_INSUFFICIENT_SOURCE_AMOUNT: 'R01',
+  R02_INSUFFICIENT_TIMEOUT: 'R02',
+  R99_APPLICATION_ERROR: 'R99'
+}
+
+export class BadRequestError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F00_BAD_REQUEST
+  }
+}
+
+export class InvalidPacketError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F01_INVALID_PACKET
+  }
+}
+
+export class UnreachableError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F02_UNREACHABLE
+  }
+}
+
+export class InvalidAmountError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F03_INVALID_AMOUNT
+  }
+}
+
+export class InsufficientDestinationAmountError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F04_INSUFFICIENT_DESTINATION_AMOUNT
+  }
+}
+
+export class WrongConditionError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F05_WRONG_CONDITION
+  }
+}
+
+export class UnexpectedPaymentError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F06_UNEXPECTED_PAYMENT
+  }
+}
+
+export class CannotReceiveError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.F07_CANNOT_RECEIVE
+  }
+}
+
+export interface AmountTooLargeErrorOpts {
+  receivedAmount: string,
+  maximumAmount: string
+}
+
+export class AmountTooLargeError extends BaseError {
+  public ilpErrorCode: string
+  public ilpData: Buffer
+  constructor (message: string, opts: AmountTooLargeErrorOpts) {
+    super(message)
+    this.ilpErrorCode = codes.F08_AMOUNT_TOO_LARGE
+
+    const writer = new Writer()
+    writer.writeUInt64(stringToTwoNumbers(opts.receivedAmount))
+    writer.writeUInt64(stringToTwoNumbers(opts.maximumAmount))
+
+    this.ilpData = writer.getBuffer()
+  }
+}
+
+export class FinalApplicationError extends BaseError {
+  public ilpErrorCode: string
+  public ilpData: Buffer
+  constructor (message: string, data: Buffer) {
+    super(message)
+    this.ilpErrorCode = codes.F99_APPLICATION_ERROR
+    this.ilpData = data
+  }
+}
+
+export class InternalError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.T00_INTERNAL_ERROR
+  }
+}
+
+export class PeerUnreachableError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.T01_PEER_UNREACHABLE
+  }
+}
+
+export class PeerBusyError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.T02_PEER_BUSY
+  }
+}
+
+export class ConnectorBusyError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.T03_CONNECTOR_BUSY
+  }
+}
+
+export class InsufficientLiquidityError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.T04_INSUFFICIENT_LIQUIDITY
+  }
+}
+
+export class RateLimitedError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.T05_RATE_LIMITED
+  }
+}
+
+export class TemporaryApplicationError extends BaseError {
+  public ilpErrorCode: string
+  public ilpData: Buffer
+  constructor (message: string, data: Buffer) {
+    super(message)
+    this.ilpErrorCode = codes.T99_APPLICATION_ERROR
+    this.ilpData = data
+  }
+}
+
+export class TransferTimedOutError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.R00_TRANSFER_TIMED_OUT
+  }
+}
+
+export class InsufficientSourceAmountError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.R01_INSUFFICIENT_SOURCE_AMOUNT
+  }
+}
+
+export class InsufficientTimeoutError extends BaseError {
+  public ilpErrorCode: string
+  constructor (message: string) {
+    super(message)
+    this.ilpErrorCode = codes.R02_INSUFFICIENT_TIMEOUT
+  }
+}
+
+export class RelativeApplicationError extends BaseError {
+  public ilpErrorCode: string
+  public ilpData: Buffer
+  constructor (message: string, data: Buffer) {
+    super(message)
+    this.ilpErrorCode = codes.R99_APPLICATION_ERROR
+    this.ilpData = data
+  }
+}

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -1,0 +1,21 @@
+import { assert } from 'chai'
+
+const { Errors } = require('..')
+
+describe('Errors', function () {
+  describe('AmountTooLargeError', function () {
+    it('encodes receivedAmount and maximumAmount', function () {
+      const error = new Errors.AmountTooLargeError('amount too large', {
+        receivedAmount: '255',
+        maximumAmount: '65535'
+      })
+
+      assert.equal(error.message, 'amount too large')
+      assert.equal(error.ilpErrorCode, Errors.codes.F08_AMOUNT_TOO_LARGE)
+      assert.deepEqual(error.ilpData, Buffer.from([
+        0, 0, 0, 0, 0, 0, 0, 0xff,
+        0, 0, 0, 0, 0, 0, 0xff, 0xff
+      ]))
+    })
+  })
+})

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -12,7 +12,7 @@ describe('Errors', function () {
 
       assert.equal(error.message, 'amount too large')
       assert.equal(error.ilpErrorCode, Errors.codes.F08_AMOUNT_TOO_LARGE)
-      assert.deepEqual(error.ilpData, Buffer.from([
+      assert.deepEqual(error.ilpErrorData, Buffer.from([
         0, 0, 0, 0, 0, 0, 0, 0xff,
         0, 0, 0, 0, 0, 0, 0xff, 0xff
       ]))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "dist",
     "module": "commonjs",
     "declaration": true,


### PR DESCRIPTION
Adds error classes from the RFCS so we don't need to reimplement them everywhere. For errors with a specific encoding (right now that's just F08 Amount too Large) these classes will also encode the error data. Also creates a function called errorToReject that turns any error type into an ILP error.

In order to get the work I had to change the target to es2017. Otherwise I got `TypeError: Class constructor ExtensibleError cannot be invoked without 'new'` 