### PR TITLE
perf: use oer-utils#dj-alloc-writer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -281,6 +281,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
@@ -1987,9 +1997,9 @@
       "dev": true
     },
     "oer-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.2.0.tgz",
-      "integrity": "sha512-WYDTeRW15E1u+hfrIJQwAzLBFu/FAOiMgRa5j/sgrvED0gYbqkKZ4ApQgfdEMiXFzvEmdKQlGcUqmloz6y+WZg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-4.0.0.tgz",
+      "integrity": "sha512-WxX0gNGSS0Lzig4IdliHlIQ03PVTpIuLFbOAag5lJrx1hWNG3f/yhx3QOmORpoXe2e53HZbeet8qoOAsiWz5BQ==",
       "requires": {
         "bignumber.js": "^7.2.1"
       }
@@ -2025,6 +2035,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "extensible-error": "^1.0.2",
     "long": "^4.0.0",
-    "oer-utils": "^3.2.0"
+    "oer-utils": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/long": "^4.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.7.0",
+    "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "codecov": "^3.0.4",
     "mocha": "^5.2.0",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -102,7 +102,7 @@ export class AmountTooLargeError extends BaseError {
     super(message)
     this.ilpErrorCode = codes.F08_AMOUNT_TOO_LARGE
 
-    const writer = new Writer()
+    const writer = new Writer(8 + 8)
     const receivedAmountLong = Long.fromString(opts.receivedAmount, true)
     const maximumAmountLong = Long.fromString(opts.maximumAmount, true)
     writer.writeUInt32(receivedAmountLong.getHighBitsUnsigned())

--- a/test/benchmarks/packet.ts
+++ b/test/benchmarks/packet.ts
@@ -1,0 +1,79 @@
+const Benchmark = require('benchmark')
+import * as PacketV1 from '../..'
+const packageV0 = process.argv[2]
+if (!packageV0) {
+  console.error('usage: node ' + process.argv.slice(0, 2).join(' ') + ' <v0>')
+  process.exit(1)
+}
+const PacketV0 = require(packageV0)
+
+const prepareObject = {
+  amount: '107',
+  executionCondition: Buffer.from('dOETbcccnl8oO+yDRhy/EmHEAU9y1I+N1lRToLhOfeE=', 'base64'),
+  expiresAt: new Date('2017-12-23T01:21:40.549Z'),
+  destination: 'example.alice',
+  data: Buffer.from('XbND/cQYmPbfQgIykTncJC3Q9VioEbRrKJGP2rN8bLA=', 'base64')
+}
+const prepareBuffer = PacketV1.serializeIlpPrepare(prepareObject)
+
+const fulfillObject = {
+  fulfillment: Buffer.from('w4ZrSHSczxE7LhXCXSQH+/wUR2/nKWuxvxvNnm5BZlA=', 'base64'),
+  data: Buffer.from('Zz/r14ozso4cDbFMmgYlGgX6gx7U7ZHrzRUOcknC5gA=', 'base64')
+}
+const fulfillBuffer = PacketV1.serializeIlpFulfill(fulfillObject)
+
+const rejectObject = {
+  code: 'F01',
+  triggeredBy: 'example.us.bob',
+  message: 'missing destination. ledger=example.us.',
+  data: Buffer.from('AAAABBBB', 'base64')
+}
+const rejectBuffer = PacketV1.serializeIlpReject(rejectObject)
+
+;(new Benchmark.Suite('serializeIlpPrepare'))
+  .add('v0', function () { PacketV0.serializeIlpPrepare(prepareObject) })
+  .add('v1', function () { PacketV1.serializeIlpPrepare(prepareObject) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})
+
+;(new Benchmark.Suite('deserializeIlpPrepare'))
+  .add('v0', function () { PacketV0.deserializeIlpPacket(prepareBuffer) })
+  .add('v1', function () { PacketV1.deserializeIlpPacket(prepareBuffer) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})
+
+;(new Benchmark.Suite('serializeIlpFulfill'))
+  .add('v0', function () { PacketV0.serializeIlpFulfill(fulfillObject) })
+  .add('v1', function () { PacketV1.serializeIlpFulfill(fulfillObject) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})
+
+;(new Benchmark.Suite('deserializeIlpFulfill'))
+  .add('v0', function () { PacketV0.deserializeIlpFulfill(fulfillBuffer) })
+  .add('v1', function () { PacketV1.deserializeIlpFulfill(fulfillBuffer) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})
+
+;(new Benchmark.Suite('serializeIlpReject'))
+  .add('v0', function () { PacketV0.serializeIlpReject(rejectObject) })
+  .add('v1', function () { PacketV1.serializeIlpReject(rejectObject) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})
+
+;(new Benchmark.Suite('deserializeIlpReject'))
+  .add('v0', function () { PacketV0.deserializeIlpReject(rejectBuffer) })
+  .add('v1', function () { PacketV1.deserializeIlpReject(rejectBuffer) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
   },
   "include": [
     "index.ts",
-    "test/*.spec.ts"
+    "test/*.spec.ts",
+    "test/benchmarks/*.ts"
   ]
 }


### PR DESCRIPTION
Depends on https://github.com/interledgerjs/oer-utils/pull/21.

Benchmarks: (before and after):

```
serializeIlpPrepare      v0 x 224,294 ops/sec ±0.84% (91 runs sampled)
serializeIlpPrepare      v1 x 418,535 ops/sec ±0.88% (91 runs sampled)
deserializeIlpPrepare    v0 x 236,698 ops/sec ±1.28% (91 runs sampled)
deserializeIlpPrepare    v1 x 322,443 ops/sec ±0.45% (91 runs sampled)
serializeIlpFulfill      v0 x 537,387 ops/sec ±0.86% (90 runs sampled)
serializeIlpFulfill      v1 x 1,054,131 ops/sec ±1.20% (88 runs sampled)
deserializeIlpFulfill    v0 x 1,079,358 ops/sec ±0.68% (94 runs sampled)
deserializeIlpFulfill    v1 x 4,630,731 ops/sec ±1.60% (89 runs sampled)
serializeIlpReject       v0 x 260,279 ops/sec ±0.82% (88 runs sampled)
serializeIlpReject       v1 x 457,782 ops/sec ±0.98% (91 runs sampled)
deserializeIlpReject     v0 x 478,236 ops/sec ±0.69% (97 runs sampled)
deserializeIlpReject     v1 x 1,333,481 ops/sec ±1.00% (89 runs sampled)
```