### PR TITLE
perf: faster interledgerTimeToDate

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -23,15 +23,17 @@ export const dateToInterledgerTime = (date: Date) => {
 }
 
 export const INTERLEDGER_TIME_LENGTH = 17
-export const INTERLEDGER_TIME_REGEX =
-  /^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{3})$/
 
 export const interledgerTimeToDate = (interledgerTime: string) => {
-  const isoTimestamp = interledgerTime.replace(
-    INTERLEDGER_TIME_REGEX,
-    '$1-$2-$3T$4:$5:$6.$7Z')
-
-  const date = new Date(isoTimestamp)
+  const date = new Date(Date.UTC(
+    +interledgerTime.slice(0, 4), // year
+    +interledgerTime.slice(4, 6) - 1, // month
+    +interledgerTime.slice(6, 8), // day
+    +interledgerTime.slice(8, 10), // hours
+    +interledgerTime.slice(10, 12), // minutes
+    +interledgerTime.slice(12, 14), // seconds
+    +interledgerTime.slice(14, 17) // milliseconds
+  ))
 
   if (!date.valueOf()) {
     throw new Error('invalid date')

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert'
+import {
+  dateToInterledgerTime,
+  interledgerTimeToDate
+} from '../src/utils/date'
+
+describe('utils/date', function () {
+  describe('interledgerTimeToDate', function () {
+    it('matches dateToInterledgerTime', function () {
+      for (let i = 0; i < 1000; i++) {
+        const year = randomBetween(1000, 10000)
+        const month = randomBetween(0, 12)
+        const day = randomBetween(0, 28)
+        const hour = randomBetween(0, 24)
+        const minute = randomBetween(0, 60)
+        const second = randomBetween(0, 60)
+        const millisecond = randomBetween(0, 1000)
+        const date = new Date(Date.UTC(year, month, day, hour, minute, second, millisecond))
+
+        const ilpDate = dateToInterledgerTime(date)
+        assert.deepEqual(interledgerTimeToDate(ilpDate), date)
+      }
+    })
+  })
+})
+
+function randomBetween (min: number, max: number): number {
+  return min + Math.floor(Math.random() * (max - min))
+}


### PR DESCRIPTION
* Optimize datetime deserialization. This improves `deserializeIlpPrepare` performance.
* Add `interledgerTimeToDate`/`dateToInterledgerTime` test.

## Benchmarks

v0: before, v1: after

```
deserializeIlpPrepare    v0 x 337,860 ops/sec ±1.19% (93 runs sampled)
deserializeIlpPrepare    v1 x 745,885 ops/sec ±0.48% (94 runs sampled)
```